### PR TITLE
workaround to rewrite temp dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23
 require (
 	github.com/kbinani/screenshot v0.0.0-20250118074034-a3924b7bbc8c
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
-	github.com/pkg/errors v0.9.1
 	go.viam.com/rdk v0.62.0
 	go.viam.com/utils v0.1.130
 	golang.org/x/sys v0.29.0
@@ -111,6 +110,7 @@ require (
 	github.com/pion/transport/v2 v2.2.10 // indirect
 	github.com/pion/turn/v2 v2.1.6 // indirect
 	github.com/pion/webrtc/v3 v3.2.36 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/cors v1.11.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require (
 	github.com/kbinani/screenshot v0.0.0-20250118074034-a3924b7bbc8c
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+	github.com/pkg/errors v0.9.1
 	go.viam.com/rdk v0.62.0
 	go.viam.com/utils v0.1.130
 	golang.org/x/sys v0.29.0
@@ -110,7 +111,6 @@ require (
 	github.com/pion/transport/v2 v2.2.10 // indirect
 	github.com/pion/turn/v2 v2.1.6 // indirect
 	github.com/pion/webrtc/v3 v3.2.36 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/cors v1.11.1 // indirect

--- a/models/module.go
+++ b/models/module.go
@@ -9,6 +9,7 @@ import (
 	"image/jpeg"
 	"math/rand/v2"
 	"os"
+	"os/user"
 	"path/filepath"
 
 	"github.com/kbinani/screenshot"
@@ -108,6 +109,9 @@ func (s *screenshotCamScreenshot) Image(ctx context.Context, mimeType string, ex
 		}
 		return buf.Bytes(), camera.ImageMetadata{MimeType: "image/jpeg"}, nil
 	}
+	td := os.TempDir()
+	user, _ := user.Current()
+	s.logger.Infof("tempdir %s, user %s", td, user.Name)
 	if !pathExists(os.TempDir()) {
 		if err := os.MkdirAll(os.TempDir(), os.ModeDir); err != nil {
 			return nil, camera.ImageMetadata{}, errw.Wrap(err, "creating temp dir")


### PR DESCRIPTION
## What changed
- when the jpeg temp dir is SystemTemp, rewrite to TEMP
## Why
There's a permission issue in some installations where os.TempDir returns c:\windows\systemtemp and the process cannot write to it. This is a workaround for that.