### PR TITLE
reuse a persistent session-1 subprocess for screenshot capture

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"image"
 	"image/jpeg"
+	"io"
 	"os"
 	"time"
 
@@ -22,18 +25,35 @@ import (
 
 // note: these flags are only relevant if the program is in parent/child mode.
 // Otherwise, the viam module system will take care of argument parsing.
-var programMode = flag.String("mode", "", "'parent' or 'child' for subprocess flow")
-var capturePath = flag.String("path", "", "filename to save image")
-var nTries = flag.Uint("n", 1, "number of images to capture")
+var programMode = flag.String("mode", "", "'parent', 'child', or 'persistent' for subprocess flow")
+var capturePath = flag.String("path", "", "filename to save image (parent/child modes only)")
+var nTries = flag.Uint("n", 1, "number of images to capture (parent mode only)")
 var displayIndex = flag.Uint("display", 0, "display index to capture when there are multiple monitors")
 
+// newStderrLogger builds a debug-level logger that writes to stderr only.
+// Used by the `persistent` and `child` subprocess modes, where stdout is
+// reserved for the binary capture protocol and any stray write would corrupt
+// the JPEG stream sent back to the parent.
+func newStderrLogger(name string) logging.Logger {
+	l := logging.NewBlankLogger(name)
+	l.AddAppender(logging.NewWriterAppender(os.Stderr))
+	l.SetLevel(logging.DEBUG)
+	return l
+}
+
 func main() {
-	logger := module.NewLoggerFromArgs("screenshot-cam")
 	flag.Parse()
+	var logger logging.Logger
 	switch *programMode {
-	case "parent":
-		fallthrough
-	case "child":
+	case "persistent", "child":
+		// Don't use module.NewLoggerFromArgs here: it appends to os.Stdout,
+		// which is our binary protocol channel.
+		logger = newStderrLogger("screenshot-cam-child")
+	default:
+		logger = module.NewLoggerFromArgs("screenshot-cam")
+	}
+	switch *programMode {
+	case "parent", "child":
 		if *capturePath == "" {
 			logger.Error("the -path argument is required in the subprocess flow")
 			return
@@ -41,17 +61,36 @@ func main() {
 	}
 	switch *programMode {
 	case "parent":
-		// parent is a test mode for spawning a child proc directly from session 0 CLI. see README.md for instructions.
+		// parent is a manual test mode for driving a persistent child directly
+		// from a session 0 CLI. see README.md for instructions.
+		child, err := subproc.StartPersistentChild("-mode persistent")
+		if err != nil {
+			panic(err)
+		}
+		defer child.Close()
+		// drain child stderr to ours so panics/log lines are visible
+		go io.Copy(os.Stderr, child.Stderr())
+
 		t0 := time.Now()
-		for range *nTries {
-			if err := subproc.SpawnSelf(fmt.Sprintf(" -mode child -path %s -display %d", *capturePath, *displayIndex)); err != nil {
+		for i := uint(0); i < *nTries; i++ {
+			data, err := child.CaptureJPEG(uint32(*displayIndex))
+			if err != nil {
+				panic(err)
+			}
+			path := *capturePath
+			if *nTries > 1 {
+				path = fmt.Sprintf("%s.%d.jpg", *capturePath, i)
+			}
+			if err := os.WriteFile(path, data, 0644); err != nil {
 				panic(err)
 			}
 		}
 		delta := time.Since(t0)
-		fmt.Printf("captured %d screenshots in %s seconds, %f per second", *nTries, (delta / time.Second).String(), float64(*nTries)/float64(delta/time.Second))
+		fmt.Printf("captured %d screenshots in %s, %f per second\n",
+			*nTries, delta.String(), float64(*nTries)/delta.Seconds())
 	case "child":
-		// child is the subprocess started in session 1 by a session 0 parent. it does the work.
+		// child is the legacy one-shot subprocess (still useful for debugging
+		// SpawnSelf). It captures a single screenshot and writes it to disk.
 		logger.Debugf("%d active displays, using index %d", screenshot.NumActiveDisplays(), *displayIndex)
 		if int(*displayIndex) >= screenshot.NumActiveDisplays() {
 			logger.Warnf("display index %d >= active displays %d, the subprocess may crash", *displayIndex, screenshot.NumActiveDisplays())
@@ -59,36 +98,59 @@ func main() {
 		if err := captureToPath(logger, *capturePath, int(*displayIndex)); err != nil {
 			panic(err)
 		}
+	case "persistent":
+		// persistent is the long-running subprocess started by the module in
+		// session 0. It serves capture requests from stdin and writes JPEGs to
+		// stdout. See subproc.RunChildLoop for the wire protocol.
+		if err := models.CheckSession(logger); err != nil {
+			logger.Warnf("error checking session: %s", err)
+		}
+		logger.Debugf("%d active displays at startup", screenshot.NumActiveDisplays())
+		if err := subproc.RunChildLoop(func(d uint32) ([]byte, error) {
+			return captureJPEG(logger, int(d))
+		}); err != nil {
+			logger.Errorf("persistent child loop ended: %s", err)
+			os.Exit(1)
+		}
 	default:
 		utils.ContextualMain(mainWithArgs, logger)
 	}
 }
 
-func captureToPath(logger logging.Logger, path string, displayIndex int) error {
-	if err := models.CheckSession(logger); err != nil {
-		logger.Warnf("error checking session: %s", err)
-	}
+// captureJPEG grabs a screenshot of the given display, downsizes anything
+// wider than 1920px, and returns the JPEG-encoded bytes.
+func captureJPEG(logger logging.Logger, displayIndex int) ([]byte, error) {
 	img, err := screenshot.CaptureDisplay(displayIndex)
 	if err != nil {
-		if err := windows.GetLastError(); err != nil {
-			logger.Errorf("windows GetLastError %s", err.Error())
+		if lastErr := windows.GetLastError(); lastErr != nil {
+			logger.Errorf("windows GetLastError %s", lastErr.Error())
 		}
-		return err
+		return nil, err
 	}
 	if img.Rect.Size().X > 1920 {
 		resized := resize.Resize(1920, 0, img, resize.Bilinear)
 		var ok bool
 		img, ok = resized.(*image.RGBA)
 		if !ok {
-			panic("resized image is not RGBA")
+			return nil, errors.New("resized image is not RGBA")
 		}
 	}
-	f, err := os.Create(path)
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func captureToPath(logger logging.Logger, path string, displayIndex int) error {
+	if err := models.CheckSession(logger); err != nil {
+		logger.Warnf("error checking session: %s", err)
+	}
+	data, err := captureJPEG(logger, displayIndex)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	if err := jpeg.Encode(f, img, nil); err != nil {
+	if err := os.WriteFile(path, data, 0644); err != nil {
 		return err
 	}
 	logger.Debugf("wrote to %s", path)

--- a/models/module.go
+++ b/models/module.go
@@ -5,13 +5,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"image"
 	"image/jpeg"
-	"math/rand/v2"
-	"os"
-	"path/filepath"
-	"strings"
+	"sync"
 	"time"
 
 	"github.com/kbinani/screenshot"
@@ -49,17 +45,16 @@ type Config struct {
 type screenshotCamScreenshot struct {
 	name resource.Name
 
-	logger       logging.Logger
-	cfg          *Config
-	hasWarnedTmp bool
+	logger logging.Logger
+	cfg    *Config
 
 	cancelCtx  context.Context
 	cancelFunc func()
 
-	// Uncomment this if the model does not have any goroutines that
-	// need to be shut down while closing.
-	// resource.TriviallyCloseable
-
+	// persistent child subprocess used in session 0 mode. nil until first use,
+	// re-created after any I/O failure.
+	childMu sync.Mutex
+	child   *subproc.PersistentChild
 }
 
 func newScreenshotCamScreenshot(ctx context.Context, deps resource.Dependencies, rawConf resource.Config, logger logging.Logger) (camera.Camera, error) {
@@ -113,10 +108,51 @@ func CheckSession(logger logging.Logger) error {
 	return nil
 }
 
+// getOrStartChild returns the cached persistent child, starting one if needed.
+// It does not hold the child mutex while doing IPC; callers should call
+// CaptureJPEG directly on the returned handle.
+func (s *screenshotCamScreenshot) getOrStartChild() (*subproc.PersistentChild, error) {
+	s.childMu.Lock()
+	defer s.childMu.Unlock()
+	if s.child != nil {
+		return s.child, nil
+	}
+	child, err := subproc.StartPersistentChild("-mode persistent")
+	if err != nil {
+		return nil, err
+	}
+	// Drain child stderr in the background. zap log lines from the subprocess
+	// land here; surface them through our logger so they show up in module logs.
+	go func(r *bufio.Reader) {
+		for {
+			line, err := r.ReadString('\n')
+			if len(line) > 0 {
+				s.logger.Debugf("[child] %s", line)
+			}
+			if err != nil {
+				return
+			}
+		}
+	}(bufio.NewReader(child.Stderr()))
+	s.child = child
+	return child, nil
+}
+
+// invalidateChild closes and clears `c` if it's still the currently cached
+// child. Called after an IPC error so the next request starts a fresh process.
+func (s *screenshotCamScreenshot) invalidateChild(c *subproc.PersistentChild) {
+	s.childMu.Lock()
+	defer s.childMu.Unlock()
+	if s.child == c {
+		s.child = nil
+		go c.Close() // don't block the caller on process teardown
+	}
+}
+
 func (s *screenshotCamScreenshot) Image(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
 	if !subproc.ShouldSpawn() {
 		// note: this code isn't reachable on windows in service mode; the NON ShouldSpawn
-		// path hits `-mode child` in main.go.
+		// path hits the persistent child below.
 		if err := CheckSession(s.logger); err != nil {
 			s.logger.Errorf("error in CheckSession: %s", err)
 		}
@@ -133,29 +169,21 @@ func (s *screenshotCamScreenshot) Image(ctx context.Context, mimeType string, ex
 		}
 		return buf.Bytes(), camera.ImageMetadata{MimeType: "image/jpeg"}, nil
 	}
-	td := os.TempDir()
-	if strings.ToLower(td) == "c:\\windows\\systemtemp" {
-		// this is an experimental workaround for an access denied bug we've seen
-		newTd := "C:\\windows\\TEMP"
-		if !s.hasWarnedTmp {
-			s.hasWarnedTmp = true
-			s.logger.Warnf("applying workaround to rewrite tempdir from %s to %s", td, newTd)
-		}
-		td = newTd
-	}
-	capturePath := filepath.Join(td, fmt.Sprintf("screenshot-cam-%d.jpg", rand.IntN(1000000)))
-	// careful: if you modify the SpawnSelf call, think through the recursion risk. The spawned subprocess
-	// should not itself check ShouldSpawn and spawn again. (Because if ShouldSpawn breaks, you'll create
-	// infinite subprocs).
-	if err := subproc.SpawnSelf(fmt.Sprintf(" -mode child -path %s -display %d", capturePath, s.cfg.DisplayIndex)); err != nil {
-		return nil, camera.ImageMetadata{}, err
-	}
-	defer os.Remove(capturePath)
-	buf, err := os.ReadFile(capturePath)
+	// Session 0 path: reuse a persistent subprocess running in the active
+	// console session. Recreating the process per request was the dominant
+	// latency on Windows.
+	child, err := s.getOrStartChild()
 	if err != nil {
 		return nil, camera.ImageMetadata{}, err
 	}
-	return buf, camera.ImageMetadata{MimeType: "image/jpeg"}, nil
+	jpegBytes, err := child.CaptureJPEG(uint32(s.cfg.DisplayIndex))
+	if err != nil {
+		// Pipe error or the child died (e.g. user logged out, taking the
+		// session with it). Drop this child so the next call respawns.
+		s.invalidateChild(child)
+		return nil, camera.ImageMetadata{}, err
+	}
+	return jpegBytes, camera.ImageMetadata{MimeType: "image/jpeg"}, nil
 }
 
 func (s *screenshotCamScreenshot) Images(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) ([]camera.NamedImage, resource.ResponseMetadata, error) {
@@ -195,8 +223,14 @@ func (s *screenshotCamScreenshot) DoCommand(ctx context.Context, cmd map[string]
 }
 
 func (s *screenshotCamScreenshot) Close(context.Context) error {
-	// Put close code here
 	s.cancelFunc()
+	s.childMu.Lock()
+	c := s.child
+	s.child = nil
+	s.childMu.Unlock()
+	if c != nil {
+		c.Close()
+	}
 	return nil
 }
 

--- a/subproc/protocol.go
+++ b/subproc/protocol.go
@@ -1,0 +1,94 @@
+package subproc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Wire protocol used by PersistentChild and RunChildLoop. Both sides are in the
+// same binary so we only care about consistency, not stability.
+//
+// Request  (parent -> child): 4 bytes, little-endian uint32 display index.
+// Response (child -> parent): 5 byte header (1 status byte + 4 byte LE uint32
+// payload length), followed by `length` bytes of payload. Status 0 means the
+// payload is JPEG bytes; non-zero means the payload is a UTF-8 error message.
+
+const (
+	statusOK  byte = 0
+	statusErr byte = 1
+)
+
+func writeRequest(w io.Writer, displayIndex uint32) error {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], displayIndex)
+	_, err := w.Write(buf[:])
+	return err
+}
+
+func readRequest(r io.Reader) (uint32, error) {
+	var buf [4]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint32(buf[:]), nil
+}
+
+func writeResponse(w io.Writer, status byte, payload []byte) error {
+	var header [5]byte
+	header[0] = status
+	binary.LittleEndian.PutUint32(header[1:], uint32(len(payload)))
+	if _, err := w.Write(header[:]); err != nil {
+		return err
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+	_, err := w.Write(payload)
+	return err
+}
+
+func readResponse(r io.Reader) (byte, []byte, error) {
+	var header [5]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return 0, nil, err
+	}
+	status := header[0]
+	length := binary.LittleEndian.Uint32(header[1:])
+	if length == 0 {
+		return status, nil, nil
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return 0, nil, err
+	}
+	return status, payload, nil
+}
+
+// RunChildLoop reads capture requests from os.Stdin in a loop, calls capture()
+// to produce JPEG bytes, and writes responses back to os.Stdout. It returns
+// nil on a clean EOF (parent closed our stdin) and an error otherwise. If
+// capture() returns an error the loop continues; the error is reported to the
+// parent in the response and the next request is served.
+func RunChildLoop(capture func(displayIndex uint32) ([]byte, error)) error {
+	for {
+		displayIndex, err := readRequest(os.Stdin)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("reading request: %w", err)
+		}
+		data, capErr := capture(displayIndex)
+		status := statusOK
+		payload := data
+		if capErr != nil {
+			status = statusErr
+			payload = []byte(capErr.Error())
+		}
+		if err := writeResponse(os.Stdout, status, payload); err != nil {
+			return fmt.Errorf("writing response: %w", err)
+		}
+	}
+}

--- a/subproc/spawn.go
+++ b/subproc/spawn.go
@@ -4,6 +4,7 @@ package subproc
 
 import (
 	"errors"
+	"io"
 )
 
 // returns true if this is running as LocalSystem and SpawnSelf is necessary for desktop interaction.
@@ -16,3 +17,19 @@ func ShouldSpawn() bool {
 func SpawnSelf(cmdArgs string) error {
 	return errors.New("SpawnSelf not supported on non-windows platforms; ShouldSpawn always returns false and your code should use that as a guard")
 }
+
+// PersistentChild is a no-op stub on non-windows platforms.
+type PersistentChild struct{}
+
+// StartPersistentChild is unsupported off Windows.
+func StartPersistentChild(cmdArgs string) (*PersistentChild, error) {
+	return nil, errors.New("StartPersistentChild not supported on non-windows platforms")
+}
+
+func (*PersistentChild) CaptureJPEG(displayIndex uint32) ([]byte, error) {
+	return nil, errors.New("not supported on non-windows platforms")
+}
+
+func (*PersistentChild) Stderr() io.Reader { return nil }
+
+func (*PersistentChild) Close() error { return nil }

--- a/subproc/spawn_windows.go
+++ b/subproc/spawn_windows.go
@@ -3,7 +3,9 @@ package subproc
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"sync"
 	"syscall"
 	"unsafe"
 
@@ -45,6 +47,10 @@ func ShouldSpawn() bool {
 
 // runs the currently running binary as a subprocess in the context of the active console session ID.
 // cmdArgs string is appended to the exec path and passed to the subprocess.
+//
+// Prefer StartPersistentChild for the hot path; SpawnSelf creates a fresh
+// process per call and is mainly retained for the manual `-mode parent` test
+// flow described in README.md.
 func SpawnSelf(cmdArgs string) error {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -55,13 +61,6 @@ func SpawnSelf(cmdArgs string) error {
 		return err
 	}
 	defer token.Close()
-	// todo: why do some docs recommend this here?
-	// var token windows.Token
-	// err = windows.DuplicateTokenEx(origToken, windows.MAXIMUM_ALLOWED, nil, windows.SecurityImpersonation, windows.TokenPrimary, &token)
-	// if err != nil {
-	// 	return fmt.Errorf("Failed to duplicate token: %v", err)
-	// }
-	// defer token.Close()
 
 	si := new(windows.StartupInfo)
 	si.Cb = uint32(unsafe.Sizeof(*si))
@@ -99,4 +98,191 @@ func SpawnSelf(cmdArgs string) error {
 	_, err = windows.WaitForSingleObject(pi.Process, windows.INFINITE)
 	// todo: do something useful with error code from subproc. currently we're not detecting failure.
 	return err
+}
+
+// PersistentChild is a long-running subprocess (started via CreateProcessAsUser
+// in the active console session) that serves capture requests over stdio
+// pipes. Reusing the process across calls amortizes the (substantial) cost of
+// spawning a fresh Go binary for every screenshot.
+type PersistentChild struct {
+	process windows.Handle
+	thread  windows.Handle
+	stdin   *os.File
+	stdout  *os.File
+	stderr  *os.File
+
+	mu        sync.Mutex // serializes request/response on stdin/stdout
+	closeOnce sync.Once
+}
+
+// makeInheritablePipe creates an anonymous pipe with both ends inheritable,
+// then clears the inherit flag on the parent's end so only the child end is
+// duplicated into the child by CreateProcessAsUser.
+func makeInheritablePipe(childIsRead bool) (child, parent windows.Handle, err error) {
+	var sa windows.SecurityAttributes
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	var r, w windows.Handle
+	if err := windows.CreatePipe(&r, &w, &sa, 0); err != nil {
+		return 0, 0, err
+	}
+	if childIsRead {
+		child, parent = r, w
+	} else {
+		child, parent = w, r
+	}
+	if err := windows.SetHandleInformation(parent, windows.HANDLE_FLAG_INHERIT, 0); err != nil {
+		windows.CloseHandle(r)
+		windows.CloseHandle(w)
+		return 0, 0, err
+	}
+	return child, parent, nil
+}
+
+// StartPersistentChild launches the current binary as a subprocess in the
+// active console session with stdio plumbed back over inheritable pipes.
+// cmdArgs is appended to the exec path. The returned PersistentChild can serve
+// many CaptureJPEG calls; on any I/O error the caller should Close it and
+// start a new one.
+func StartPersistentChild(cmdArgs string) (_ *PersistentChild, retErr error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	token, err := activeUserToken()
+	if err != nil {
+		return nil, err
+	}
+	defer token.Close()
+
+	stdinChild, stdinParent, err := makeInheritablePipe(true)
+	if err != nil {
+		return nil, fmt.Errorf("creating stdin pipe: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			windows.CloseHandle(stdinParent)
+		}
+	}()
+
+	stdoutChild, stdoutParent, err := makeInheritablePipe(false)
+	if err != nil {
+		windows.CloseHandle(stdinChild)
+		return nil, fmt.Errorf("creating stdout pipe: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			windows.CloseHandle(stdoutParent)
+		}
+	}()
+
+	stderrChild, stderrParent, err := makeInheritablePipe(false)
+	if err != nil {
+		windows.CloseHandle(stdinChild)
+		windows.CloseHandle(stdoutChild)
+		return nil, fmt.Errorf("creating stderr pipe: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			windows.CloseHandle(stderrParent)
+		}
+	}()
+
+	si := new(windows.StartupInfo)
+	si.Cb = uint32(unsafe.Sizeof(*si))
+	si.Desktop, err = syscall.UTF16PtrFromString("Winsta0\\Default")
+	if err != nil {
+		windows.CloseHandle(stdinChild)
+		windows.CloseHandle(stdoutChild)
+		windows.CloseHandle(stderrChild)
+		return nil, err
+	}
+	si.Flags = windows.STARTF_USESTDHANDLES
+	si.StdInput = stdinChild
+	si.StdOutput = stdoutChild
+	si.StdErr = stderrChild
+
+	cmdLine, err := syscall.UTF16PtrFromString(execPath + " " + cmdArgs)
+	if err != nil {
+		windows.CloseHandle(stdinChild)
+		windows.CloseHandle(stdoutChild)
+		windows.CloseHandle(stderrChild)
+		return nil, err
+	}
+
+	pi := new(windows.ProcessInformation)
+	if err := windows.CreateProcessAsUser(
+		token,
+		nil,
+		cmdLine,
+		nil,
+		nil,
+		true, // bInheritHandles: required so the child receives our pipe ends
+		0,
+		nil,
+		nil,
+		si,
+		pi,
+	); err != nil {
+		windows.CloseHandle(stdinChild)
+		windows.CloseHandle(stdoutChild)
+		windows.CloseHandle(stderrChild)
+		return nil, fmt.Errorf("CreateProcessAsUser failed: %v", err)
+	}
+	// The child now owns duplicates of the child-side handles; close ours.
+	windows.CloseHandle(stdinChild)
+	windows.CloseHandle(stdoutChild)
+	windows.CloseHandle(stderrChild)
+
+	return &PersistentChild{
+		process: pi.Process,
+		thread:  pi.Thread,
+		stdin:   os.NewFile(uintptr(stdinParent), "child-stdin"),
+		stdout:  os.NewFile(uintptr(stdoutParent), "child-stdout"),
+		stderr:  os.NewFile(uintptr(stderrParent), "child-stderr"),
+	}, nil
+}
+
+// CaptureJPEG asks the child to capture the given display and returns the
+// JPEG payload it writes back. Safe for concurrent callers (calls are
+// serialized internally so they don't interleave on the pipes).
+func (p *PersistentChild) CaptureJPEG(displayIndex uint32) ([]byte, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := writeRequest(p.stdin, displayIndex); err != nil {
+		return nil, fmt.Errorf("writing capture request: %w", err)
+	}
+	status, payload, err := readResponse(p.stdout)
+	if err != nil {
+		return nil, fmt.Errorf("reading capture response: %w", err)
+	}
+	if status != statusOK {
+		return nil, fmt.Errorf("child capture error: %s", string(payload))
+	}
+	return payload, nil
+}
+
+// Stderr returns a reader for the child's stderr stream. The caller MUST
+// drain it (e.g. in a goroutine) or the child can block writing log lines
+// once the OS pipe buffer fills.
+func (p *PersistentChild) Stderr() io.Reader {
+	return p.stderr
+}
+
+// Close terminates the child process and releases its handles. Safe to call
+// multiple times.
+func (p *PersistentChild) Close() error {
+	p.closeOnce.Do(func() {
+		// Closing stdin signals EOF to the child loop, which exits cleanly.
+		_ = p.stdin.Close()
+		event, _ := windows.WaitForSingleObject(p.process, 2000)
+		if event != 0 { // not WAIT_OBJECT_0 -> didn't exit in time, force it
+			_ = windows.TerminateProcess(p.process, 1)
+		}
+		_ = windows.CloseHandle(p.process)
+		_ = windows.CloseHandle(p.thread)
+		_ = p.stdout.Close()
+		_ = p.stderr.Close()
+	})
+	return nil
 }


### PR DESCRIPTION
Each Image() call was paying for a fresh CreateProcessAsUser, full Go
runtime startup, and a JPEG round trip through a temp file. The process
spin-up dominated latency on Windows.

Now the module starts the subprocess once (lazily) and keeps it alive,
talking over inheritable stdio pipes with a tiny binary protocol
(uint32 display index in, [status, length, payload] out). The child
loops in a new `-mode persistent` handler. On any pipe error or child
death (e.g. user logout ending the session), the cached child is
invalidated and the next call respawns. The temp-file workaround for
C:\Windows\SystemTemp drops out as a side effect.

The legacy `-mode child` flow and SpawnSelf are retained for the
session-0 manual test described in README.md, and `-mode parent` now
drives a persistent child so the benchmark reflects the new fast path.