### PR TITLE
Windows: improve persistent mode; restore original one-off child mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"image/jpeg"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/kbinani/screenshot"
@@ -29,6 +30,8 @@ var programMode = flag.String("mode", "", "'parent', 'child', or 'persistent' fo
 var capturePath = flag.String("path", "", "filename to save image (parent/child modes only)")
 var nTries = flag.Uint("n", 1, "number of images to capture (parent mode only)")
 var displayIndex = flag.Uint("display", 0, "display index to capture when there are multiple monitors")
+var resizeWidth = flag.Uint("resize-width", 0, "resize captured image to this width (0 = no resize)")
+var resizeHeight = flag.Uint("resize-height", 0, "resize captured image to this height (0 = no resize)")
 
 // newStderrLogger builds a debug-level logger that writes to stderr only.
 // Used by the `persistent` and `child` subprocess modes, where stdout is
@@ -45,10 +48,12 @@ func main() {
 	flag.Parse()
 	var logger logging.Logger
 	switch *programMode {
-	case "persistent", "child":
+	case "persistent":
 		// Don't use module.NewLoggerFromArgs here: it appends to os.Stdout,
 		// which is our binary protocol channel.
 		logger = newStderrLogger("screenshot-cam-child")
+	case "child":
+		logger = module.NewLoggerFromArgs("screenshot-cam-child")
 	default:
 		logger = module.NewLoggerFromArgs("screenshot-cam")
 	}
@@ -61,9 +66,19 @@ func main() {
 	}
 	switch *programMode {
 	case "parent":
-		// parent is a manual test mode for driving a persistent child directly
+		// parent is a test mode for spawning a child proc directly from session 0 CLI. see README.md for instructions.
+		t0 := time.Now()
+		for range *nTries {
+			if err := subproc.SpawnSelf(fmt.Sprintf(" -mode child -path %s -display %d", *capturePath, *displayIndex)); err != nil {
+				panic(err)
+			}
+		}
+		delta := time.Since(t0)
+		fmt.Printf("captured %d screenshots in %s seconds, %f per second", *nTries, (delta / time.Second).String(), float64(*nTries)/float64(delta/time.Second))
+	case "pparent":
+		// pparent is a manual test mode for driving a persistent child directly
 		// from a session 0 CLI. see README.md for instructions.
-		child, err := subproc.StartPersistentChild("-mode persistent")
+		child, err := subproc.StartPersistentChild("-mode persistent", uint32(*displayIndex), 3)
 		if err != nil {
 			panic(err)
 		}
@@ -73,16 +88,19 @@ func main() {
 
 		t0 := time.Now()
 		for i := uint(0); i < *nTries; i++ {
-			data, err := child.CaptureJPEG(uint32(*displayIndex))
+			data, err := child.LatestFrame()
 			if err != nil {
 				panic(err)
 			}
 			path := *capturePath
 			if *nTries > 1 {
-				path = fmt.Sprintf("%s.%d.jpg", *capturePath, i)
+				path = filepath.Join(*capturePath, fmt.Sprintf("screenshot-cam.%d.jpg", i))
 			}
 			if err := os.WriteFile(path, data, 0644); err != nil {
 				panic(err)
+			}
+			if *nTries > 1 {
+				time.Sleep(100 * time.Millisecond) // pace manual test
 			}
 		}
 		delta := time.Since(t0)
@@ -100,14 +118,14 @@ func main() {
 		}
 	case "persistent":
 		// persistent is the long-running subprocess started by the module in
-		// session 0. It serves capture requests from stdin and writes JPEGs to
-		// stdout. See subproc.RunChildLoop for the wire protocol.
+		// session 0. It continuously captures screenshots and streams them to
+		// the parent over stdout. See subproc.RunContinuousChildLoop.
 		if err := models.CheckSession(logger); err != nil {
 			logger.Warnf("error checking session: %s", err)
 		}
 		logger.Debugf("%d active displays at startup", screenshot.NumActiveDisplays())
-		if err := subproc.RunChildLoop(func(d uint32) ([]byte, error) {
-			return captureJPEG(logger, int(d))
+		if err := subproc.RunContinuousChildLoop(func(d uint32, buf *bytes.Buffer) ([]byte, error) {
+			return captureJPEG(logger, int(d), *resizeWidth, *resizeHeight, buf)
 		}); err != nil {
 			logger.Errorf("persistent child loop ended: %s", err)
 			os.Exit(1)
@@ -117,9 +135,11 @@ func main() {
 	}
 }
 
-// captureJPEG grabs a screenshot of the given display, downsizes anything
-// wider than 1920px, and returns the JPEG-encoded bytes.
-func captureJPEG(logger logging.Logger, displayIndex int) ([]byte, error) {
+// captureJPEG grabs a screenshot of the given display, optionally resizes it,
+// and returns the JPEG-encoded bytes. If targetW/targetH are both non-zero they
+// take priority; otherwise images wider than 1920px are downscaled to fit.
+func captureJPEG(logger logging.Logger, displayIndex int, targetW, targetH uint, buf *bytes.Buffer) ([]byte, error) {
+	buf.Reset()
 	img, err := screenshot.CaptureDisplay(displayIndex)
 	if err != nil {
 		if lastErr := windows.GetLastError(); lastErr != nil {
@@ -127,7 +147,15 @@ func captureJPEG(logger logging.Logger, displayIndex int) ([]byte, error) {
 		}
 		return nil, err
 	}
-	if img.Rect.Size().X > 1920 {
+	if targetW > 0 && targetH > 0 {
+		// TODO: nfnt/resize is pure-go and not that fast
+		resized := resize.Resize(targetW, targetH, img, resize.Bilinear)
+		var ok bool
+		img, ok = resized.(*image.RGBA)
+		if !ok {
+			return nil, errors.New("resized image is not RGBA")
+		}
+	} else if img.Bounds().Dx() > 1920 {
 		resized := resize.Resize(1920, 0, img, resize.Bilinear)
 		var ok bool
 		img, ok = resized.(*image.RGBA)
@@ -135,8 +163,7 @@ func captureJPEG(logger logging.Logger, displayIndex int) ([]byte, error) {
 			return nil, errors.New("resized image is not RGBA")
 		}
 	}
-	var buf bytes.Buffer
-	if err := jpeg.Encode(&buf, img, nil); err != nil {
+	if err := jpeg.Encode(buf, img, nil); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
@@ -146,7 +173,8 @@ func captureToPath(logger logging.Logger, path string, displayIndex int) error {
 	if err := models.CheckSession(logger); err != nil {
 		logger.Warnf("error checking session: %s", err)
 	}
-	data, err := captureJPEG(logger, displayIndex)
+	var buf bytes.Buffer
+	data, err := captureJPEG(logger, displayIndex, 0, 0, &buf)
 	if err != nil {
 		return err
 	}

--- a/models/module.go
+++ b/models/module.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/kbinani/screenshot"
@@ -71,8 +70,7 @@ type screenshotCamScreenshot struct {
 
 	// persistent child subprocess used in session 0 mode. nil until first use,
 	// re-created after any I/O failure.
-	childMu sync.Mutex
-	child   *subproc.PersistentChild
+	child *subproc.PersistentChild
 }
 
 func newScreenshotCamScreenshot(ctx context.Context, deps resource.Dependencies, rawConf resource.Config, logger logging.Logger) (camera.Camera, error) {
@@ -127,8 +125,6 @@ func CheckSession(logger logging.Logger) error {
 
 // getOrStartPersistentChild returns the cached persistent child, starting one if needed.
 func (s *screenshotCamScreenshot) getOrStartPersistentChild() (*subproc.PersistentChild, error) {
-	s.childMu.Lock()
-	defer s.childMu.Unlock()
 	if s.child != nil {
 		return s.child, nil
 	}
@@ -174,8 +170,6 @@ func (s *screenshotCamScreenshot) getOrStartPersistentChild() (*subproc.Persiste
 // invalidateChild closes and clears `c` if it's still the currently cached
 // child. Called after an IPC error so the next request starts a fresh process.
 func (s *screenshotCamScreenshot) invalidateChild(c *subproc.PersistentChild) {
-	s.childMu.Lock()
-	defer s.childMu.Unlock()
 	if s.child == c {
 		s.child = nil
 		go c.Close() // don't block the caller on process teardown
@@ -265,10 +259,8 @@ func (s *screenshotCamScreenshot) DoCommand(ctx context.Context, cmd map[string]
 
 func (s *screenshotCamScreenshot) Close(context.Context) error {
 	s.cancelFunc()
-	s.childMu.Lock()
 	c := s.child
 	s.child = nil
-	s.childMu.Unlock()
 	if c != nil {
 		c.Close()
 	}

--- a/models/module.go
+++ b/models/module.go
@@ -157,6 +157,17 @@ func (s *screenshotCamScreenshot) getOrStartPersistentChild() (*subproc.Persiste
 			}
 		}
 	}(bufio.NewReader(child.Stderr()))
+	// Supervisor: if the child dies unexpectedly, exit the module process so
+	// the viam-server/agent can restart us cleanly. Only fires on crashes —
+	// clean shutdowns via Close() set Closed() and are ignored.
+	go func(c *subproc.PersistentChild) {
+		<-c.Done()
+		if c.Closed() {
+			return
+		}
+		s.logger.Errorf("screenshot-cam persistent child died unexpectedly; exiting module process")
+		os.Exit(1)
+	}(child)
 	return child, nil
 }
 

--- a/models/module.go
+++ b/models/module.go
@@ -5,8 +5,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"image"
+	"fmt"
 	"image/jpeg"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,13 +23,15 @@ import (
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/spatialmath"
+	"go.viam.com/rdk/utils"
 	"golang.org/x/sys/windows"
 )
 
 var (
-	Screenshot                     = resource.NewModel("viam", "screenshot-cam", "screenshot")
-	errUnimplemented               = errors.New("unimplemented")
-	_                camera.Camera = (*screenshotCamScreenshot)(nil)
+	Screenshot                      = resource.NewModel("viam", "screenshot-cam", "screenshot")
+	errUnimplemented                = errors.New("unimplemented")
+	_                 camera.Camera = (*screenshotCamScreenshot)(nil)
+	shouldSpawnCached               = subproc.ShouldSpawn()
 )
 
 func init() {
@@ -40,13 +46,25 @@ type Config struct {
 	resource.TriviallyValidateConfig
 	// index of display to capture (relevant when there are multiple monitors)
 	DisplayIndex int `json:"display_index"`
+	// when true, use a persistent child process that continuously captures
+	// screenshots into a ring buffer. When false (default), spawn a one-shot
+	// child process per capture request.
+	PersistentMode bool `json:"persistent_mode,omitempty"`
+	// number of slots in the frame ring buffer (minimum 4, rounded up to a
+	// power of 2; only used in persistent mode).
+	BufferSize int `json:"buffer_size,omitempty"`
+	// target resize dimensions for captured screenshots (0 = use default behavior)
+	ResizeWidth  int `json:"resize_width,omitempty"`
+	ResizeHeight int `json:"resize_height,omitempty"`
 }
 
 type screenshotCamScreenshot struct {
+	resource.AlwaysRebuild
 	name resource.Name
 
-	logger logging.Logger
-	cfg    *Config
+	logger       logging.Logger
+	cfg          *Config
+	hasWarnedTmp bool
 
 	cancelCtx  context.Context
 	cancelFunc func()
@@ -76,14 +94,13 @@ func newScreenshotCamScreenshot(ctx context.Context, deps resource.Dependencies,
 		cancelCtx:  cancelCtx,
 		cancelFunc: cancelFunc,
 	}
-	return s, nil
-}
-func (s *screenshotCamScreenshot) Reconfigure(ctx context.Context, deps resource.Dependencies, rawConf resource.Config) error {
-	conf, err := resource.NativeConfig[*Config](rawConf)
-	if err == nil {
-		s.cfg = conf
+	if subproc.ShouldSpawn() && conf.PersistentMode {
+		s.child, err = s.getOrStartPersistentChild()
+		if err != nil {
+			return nil, err
+		}
 	}
-	return err
+	return s, nil
 }
 
 func (s *screenshotCamScreenshot) Name() resource.Name {
@@ -108,16 +125,22 @@ func CheckSession(logger logging.Logger) error {
 	return nil
 }
 
-// getOrStartChild returns the cached persistent child, starting one if needed.
-// It does not hold the child mutex while doing IPC; callers should call
-// CaptureJPEG directly on the returned handle.
-func (s *screenshotCamScreenshot) getOrStartChild() (*subproc.PersistentChild, error) {
+// getOrStartPersistentChild returns the cached persistent child, starting one if needed.
+func (s *screenshotCamScreenshot) getOrStartPersistentChild() (*subproc.PersistentChild, error) {
 	s.childMu.Lock()
 	defer s.childMu.Unlock()
 	if s.child != nil {
 		return s.child, nil
 	}
-	child, err := subproc.StartPersistentChild("-mode persistent")
+	bufSize := s.cfg.BufferSize
+	if bufSize < 4 {
+		bufSize = 4
+	}
+	cmdArgs := "-mode persistent"
+	if s.cfg.ResizeWidth > 0 && s.cfg.ResizeHeight > 0 {
+		cmdArgs += fmt.Sprintf(" -resize-width %d -resize-height %d", s.cfg.ResizeWidth, s.cfg.ResizeHeight)
+	}
+	child, err := subproc.StartPersistentChild(cmdArgs, uint32(s.cfg.DisplayIndex), bufSize)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +157,6 @@ func (s *screenshotCamScreenshot) getOrStartChild() (*subproc.PersistentChild, e
 			}
 		}
 	}(bufio.NewReader(child.Stderr()))
-	s.child = child
 	return child, nil
 }
 
@@ -150,7 +172,7 @@ func (s *screenshotCamScreenshot) invalidateChild(c *subproc.PersistentChild) {
 }
 
 func (s *screenshotCamScreenshot) Image(ctx context.Context, mimeType string, extra map[string]interface{}) ([]byte, camera.ImageMetadata, error) {
-	if !subproc.ShouldSpawn() {
+	if !shouldSpawnCached {
 		// note: this code isn't reachable on windows in service mode; the NON ShouldSpawn
 		// path hits the persistent child below.
 		if err := CheckSession(s.logger); err != nil {
@@ -168,38 +190,46 @@ func (s *screenshotCamScreenshot) Image(ctx context.Context, mimeType string, ex
 			return nil, camera.ImageMetadata{}, err
 		}
 		return buf.Bytes(), camera.ImageMetadata{MimeType: "image/jpeg"}, nil
+	} else if s.cfg.PersistentMode {
+		jpegBytes, err := s.child.LatestFrame()
+		if err != nil {
+			return nil, camera.ImageMetadata{}, err
+		}
+		return jpegBytes, camera.ImageMetadata{MimeType: "image/jpeg"}, nil
 	}
-	// Session 0 path: reuse a persistent subprocess running in the active
-	// console session. Recreating the process per request was the dominant
-	// latency on Windows.
-	child, err := s.getOrStartChild()
+	td := os.TempDir()
+	if strings.ToLower(td) == "c:\\windows\\systemtemp" {
+		// this is an experimental workaround for an access denied bug we've seen
+		newTd := "C:\\windows\\TEMP"
+		if !s.hasWarnedTmp {
+			s.hasWarnedTmp = true
+			s.logger.Warnf("applying workaround to rewrite tempdir from %s to %s", td, newTd)
+		}
+		td = newTd
+	}
+	capturePath := filepath.Join(td, fmt.Sprintf("screenshot-cam-%d.jpg", rand.IntN(1000000)))
+	// careful: if you modify the SpawnSelf call, think through the recursion risk. The spawned subprocess
+	// should not itself check ShouldSpawn and spawn again. (Because if ShouldSpawn breaks, you'll create
+	// infinite subprocs).
+	if err := subproc.SpawnSelf(fmt.Sprintf(" -mode child -path %s -display %d", capturePath, s.cfg.DisplayIndex)); err != nil {
+		return nil, camera.ImageMetadata{}, err
+	}
+	defer os.Remove(capturePath)
+	buf, err := os.ReadFile(capturePath)
 	if err != nil {
 		return nil, camera.ImageMetadata{}, err
 	}
-	jpegBytes, err := child.CaptureJPEG(uint32(s.cfg.DisplayIndex))
-	if err != nil {
-		// Pipe error or the child died (e.g. user logged out, taking the
-		// session with it). Drop this child so the next call respawns.
-		s.invalidateChild(child)
-		return nil, camera.ImageMetadata{}, err
-	}
-	return jpegBytes, camera.ImageMetadata{MimeType: "image/jpeg"}, nil
+	return buf, camera.ImageMetadata{MimeType: "image/jpeg"}, nil
 }
 
 func (s *screenshotCamScreenshot) Images(ctx context.Context, filterSourceNames []string, extra map[string]interface{}) ([]camera.NamedImage, resource.ResponseMetadata, error) {
-	mimetype := "image/jpeg"
-	raw, _, err := s.Image(ctx, mimetype, nil)
+	raw, _, err := s.Image(ctx, utils.MimeTypeJPEG, nil)
 	if err != nil {
 		return nil, resource.ResponseMetadata{}, err
 	}
 
-	reader := bytes.NewReader(raw)
-	img, _, err := image.Decode(reader)
-	if err != nil {
-		return nil, resource.ResponseMetadata{}, err
-	}
 
-	named, err := camera.NamedImageFromImage(img, "screen", mimetype, data.Annotations{})
+	named, err := camera.NamedImageFromBytes(raw, "screen", utils.MimeTypeJPEG, data.Annotations{})
 	if err != nil {
 		return nil, resource.ResponseMetadata{}, err
 	}

--- a/subproc/protocol.go
+++ b/subproc/protocol.go
@@ -82,6 +82,10 @@ func RunContinuousChildLoop(capture func(displayIndex uint32, buf *bytes.Buffer)
 		}
 	}()
 
+	// don't do this faster than ~30fps. if capture takes 80ms+ as observed, we shouldn't get here
+	ticker := time.NewTicker(33 * time.Millisecond)
+	defer ticker.Stop()
+
 	var buf bytes.Buffer
 	for {
 		select {
@@ -89,7 +93,6 @@ func RunContinuousChildLoop(capture func(displayIndex uint32, buf *bytes.Buffer)
 			return nil
 		default:
 		}
-		start := time.Now()
 		data, capErr := capture(currentDisplay.Load(), &buf)
 		if capErr != nil {
 			fmt.Fprintf(os.Stderr, "capture error: %v\n", capErr)
@@ -98,10 +101,10 @@ func RunContinuousChildLoop(capture func(displayIndex uint32, buf *bytes.Buffer)
 		if err := writeFrame(os.Stdout, data); err != nil {
 			return fmt.Errorf("writing frame: %w", err)
 		}
-		elapsed := time.Since(start).Milliseconds()
-		// don't do this faster than ~30fps. if capture takes 80ms+ as observed, we shouldn't get here
-		if elapsed < 30 {
-			time.Sleep(time.Duration(33-elapsed) * time.Millisecond)
+		select {
+		case <-done:
+			return nil
+		case <-ticker.C:
 		}
 	}
 }

--- a/subproc/protocol.go
+++ b/subproc/protocol.go
@@ -1,33 +1,33 @@
 package subproc
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
+	"sync/atomic"
+	"time"
 )
 
-// Wire protocol used by PersistentChild and RunChildLoop. Both sides are in the
-// same binary so we only care about consistency, not stability.
+// Wire protocol used by PersistentChild and RunContinuousChildLoop.
 //
-// Request  (parent -> child): 4 bytes, little-endian uint32 display index.
-// Response (child -> parent): 5 byte header (1 status byte + 4 byte LE uint32
-// payload length), followed by `length` bytes of payload. Status 0 means the
-// payload is JPEG bytes; non-zero means the payload is a UTF-8 error message.
+// Config  (parent -> child on stdin, sent at startup and on reconfigure):
+//
+//	[4 bytes LE uint32: display index]
+//
+// Frames  (child -> parent on stdout, continuous stream):
+//
+//	[4 bytes LE uint32: payload length] [payload: JPEG bytes]
 
-const (
-	statusOK  byte = 0
-	statusErr byte = 1
-)
-
-func writeRequest(w io.Writer, displayIndex uint32) error {
+func writeConfig(w io.Writer, displayIndex uint32) error {
 	var buf [4]byte
 	binary.LittleEndian.PutUint32(buf[:], displayIndex)
 	_, err := w.Write(buf[:])
 	return err
 }
 
-func readRequest(r io.Reader) (uint32, error) {
+func readConfig(r io.Reader) (uint32, error) {
 	var buf [4]byte
 	if _, err := io.ReadFull(r, buf[:]); err != nil {
 		return 0, err
@@ -35,60 +35,73 @@ func readRequest(r io.Reader) (uint32, error) {
 	return binary.LittleEndian.Uint32(buf[:]), nil
 }
 
-func writeResponse(w io.Writer, status byte, payload []byte) error {
-	var header [5]byte
-	header[0] = status
-	binary.LittleEndian.PutUint32(header[1:], uint32(len(payload)))
+func writeFrame(w io.Writer, data []byte) error {
+	var header [4]byte
+	binary.LittleEndian.PutUint32(header[:], uint32(len(data)))
 	if _, err := w.Write(header[:]); err != nil {
 		return err
 	}
-	if len(payload) == 0 {
-		return nil
-	}
-	_, err := w.Write(payload)
+	_, err := w.Write(data)
 	return err
 }
 
-func readResponse(r io.Reader) (byte, []byte, error) {
-	var header [5]byte
+func readFrame(r io.Reader) ([]byte, error) {
+	var header [4]byte
 	if _, err := io.ReadFull(r, header[:]); err != nil {
-		return 0, nil, err
+		return nil, err
 	}
-	status := header[0]
-	length := binary.LittleEndian.Uint32(header[1:])
-	if length == 0 {
-		return status, nil, nil
-	}
+	length := binary.LittleEndian.Uint32(header[:])
 	payload := make([]byte, length)
 	if _, err := io.ReadFull(r, payload); err != nil {
-		return 0, nil, err
+		return nil, err
 	}
-	return status, payload, nil
+	return payload, nil
 }
 
-// RunChildLoop reads capture requests from os.Stdin in a loop, calls capture()
-// to produce JPEG bytes, and writes responses back to os.Stdout. It returns
-// nil on a clean EOF (parent closed our stdin) and an error otherwise. If
-// capture() returns an error the loop continues; the error is reported to the
-// parent in the response and the next request is served.
-func RunChildLoop(capture func(displayIndex uint32) ([]byte, error)) error {
-	for {
-		displayIndex, err := readRequest(os.Stdin)
-		if err != nil {
-			if err == io.EOF {
-				return nil
+// RunContinuousChildLoop reads an initial config from stdin, then continuously
+// calls capture and writes JPEG frames to stdout. It watches stdin for config
+// updates (display index changes) and EOF (shutdown signal from parent).
+func RunContinuousChildLoop(capture func(displayIndex uint32, buf *bytes.Buffer) ([]byte, error)) error {
+	displayIndex, err := readConfig(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("reading initial config: %w", err)
+	}
+	var currentDisplay atomic.Uint32
+	currentDisplay.Store(displayIndex)
+
+	//// Watch stdin for config updates and EOF.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			idx, err := readConfig(os.Stdin)
+			if err != nil {
+				return // EOF or broken pipe -> parent wants us to exit
 			}
-			return fmt.Errorf("reading request: %w", err)
+			currentDisplay.Store(idx)
 		}
-		data, capErr := capture(displayIndex)
-		status := statusOK
-		payload := data
+	}()
+
+	var buf bytes.Buffer
+	for {
+		select {
+		case <-done:
+			return nil
+		default:
+		}
+		start := time.Now()
+		data, capErr := capture(currentDisplay.Load(), &buf)
 		if capErr != nil {
-			status = statusErr
-			payload = []byte(capErr.Error())
+			fmt.Fprintf(os.Stderr, "capture error: %v\n", capErr)
+			continue
 		}
-		if err := writeResponse(os.Stdout, status, payload); err != nil {
-			return fmt.Errorf("writing response: %w", err)
+		if err := writeFrame(os.Stdout, data); err != nil {
+			return fmt.Errorf("writing frame: %w", err)
+		}
+		elapsed := time.Since(start).Milliseconds()
+		// don't do this faster than ~30fps. if capture takes 80ms+ as observed, we shouldn't get here
+		if elapsed < 30 {
+			time.Sleep(time.Duration(33-elapsed) * time.Millisecond)
 		}
 	}
 }

--- a/subproc/ringbuf.go
+++ b/subproc/ringbuf.go
@@ -1,0 +1,74 @@
+package subproc
+
+import (
+	"sync/atomic"
+)
+
+// paddedSlot isolates each atomic pointer on its own cache line so the writer's
+// Store to one slot doesn't invalidate readers' Load from adjacent slots.
+type paddedSlot struct {
+	ptr atomic.Pointer[[]byte]
+	_   [64 - 8]byte
+}
+
+// RingBuffer is a lock-free, single-writer, multiple-reader ring buffer.
+// The writer calls Store to publish new frames; any number of concurrent
+// readers call Load to retrieve the latest frame. Load uses a seqlock-style
+// check to detect if the writer has cycled back to the reader's slot.
+//
+// Fields are padded to separate cache lines: count (written every frame by
+// the writer) is isolated from size/slots (read-only after construction).
+type RingBuffer struct {
+	count atomic.Uint64
+	_     [64 - 8]byte
+	slots []paddedSlot
+	size  uint64 // power of 2
+	mask  uint64 // size - 1
+}
+
+// NewRingBuffer creates a ring buffer with at least `size` slots, rounded up
+// to the next power of 2. A minimum of 4 slots is enforced.
+func NewRingBuffer(size int) *RingBuffer {
+	if size < 4 {
+		size = 4
+	}
+	// round up to next power of 2
+	p := 1
+	for p < size {
+		p <<= 1
+	}
+	size = p
+	return &RingBuffer{
+		slots: make([]paddedSlot, size),
+		size:  uint64(size),
+		mask:  uint64(size - 1),
+	}
+}
+
+// Store publishes data into the next slot, then advances the counter.
+// Must be called from a single goroutine (the writer).
+func (rb *RingBuffer) Store(data []byte) {
+	next := (rb.count.Load() + 1) & rb.mask
+	rb.slots[next].ptr.Store(&data)
+	rb.count.Add(1)
+}
+
+// Load returns the most recent frame, or nil if no frame has been stored yet.
+// Safe for concurrent use by multiple readers.
+func (rb *RingBuffer) Load() []byte {
+	for {
+		n := rb.count.Load()
+		if n == 0 {
+			return nil
+		}
+		p := rb.slots[n&rb.mask].ptr.Load()
+		// If the writer has advanced size+ times since we read the counter,
+		// this slot may have been recycled. Retry with the current counter.
+		if rb.count.Load()-n < rb.size {
+			if p == nil {
+				return nil
+			}
+			return *p
+		}
+	}
+}

--- a/subproc/spawn.go
+++ b/subproc/spawn.go
@@ -22,12 +22,16 @@ func SpawnSelf(cmdArgs string) error {
 type PersistentChild struct{}
 
 // StartPersistentChild is unsupported off Windows.
-func StartPersistentChild(cmdArgs string) (*PersistentChild, error) {
+func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (*PersistentChild, error) {
 	return nil, errors.New("StartPersistentChild not supported on non-windows platforms")
 }
 
-func (*PersistentChild) CaptureJPEG(displayIndex uint32) ([]byte, error) {
+func (*PersistentChild) LatestFrame() ([]byte, error) {
 	return nil, errors.New("not supported on non-windows platforms")
+}
+
+func (*PersistentChild) UpdateDisplayIndex(displayIndex uint32) error {
+	return errors.New("not supported on non-windows platforms")
 }
 
 func (*PersistentChild) Stderr() io.Reader { return nil }

--- a/subproc/spawn.go
+++ b/subproc/spawn.go
@@ -36,4 +36,12 @@ func (*PersistentChild) UpdateDisplayIndex(displayIndex uint32) error {
 
 func (*PersistentChild) Stderr() io.Reader { return nil }
 
+func (*PersistentChild) Done() <-chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}
+
+func (*PersistentChild) Closed() bool { return true }
+
 func (*PersistentChild) Close() error { return nil }

--- a/subproc/spawn_windows.go
+++ b/subproc/spawn_windows.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -47,10 +49,6 @@ func ShouldSpawn() bool {
 
 // runs the currently running binary as a subprocess in the context of the active console session ID.
 // cmdArgs string is appended to the exec path and passed to the subprocess.
-//
-// Prefer StartPersistentChild for the hot path; SpawnSelf creates a fresh
-// process per call and is mainly retained for the manual `-mode parent` test
-// flow described in README.md.
 func SpawnSelf(cmdArgs string) error {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -61,6 +59,13 @@ func SpawnSelf(cmdArgs string) error {
 		return err
 	}
 	defer token.Close()
+	// todo: why do some docs recommend this here?
+	// var token windows.Token
+	// err = windows.DuplicateTokenEx(origToken, windows.MAXIMUM_ALLOWED, nil, windows.SecurityImpersonation, windows.TokenPrimary, &token)
+	// if err != nil {
+	// 	return fmt.Errorf("Failed to duplicate token: %v", err)
+	// }
+	// defer token.Close()
 
 	si := new(windows.StartupInfo)
 	si.Cb = uint32(unsafe.Sizeof(*si))
@@ -101,9 +106,9 @@ func SpawnSelf(cmdArgs string) error {
 }
 
 // PersistentChild is a long-running subprocess (started via CreateProcessAsUser
-// in the active console session) that serves capture requests over stdio
-// pipes. Reusing the process across calls amortizes the (substantial) cost of
-// spawning a fresh Go binary for every screenshot.
+// in the active console session) that continuously captures screenshots and
+// streams them back over a stdout pipe. The parent reads frames into a
+// RingBuffer and serves them to callers via LatestFrame.
 type PersistentChild struct {
 	process windows.Handle
 	thread  windows.Handle
@@ -111,7 +116,11 @@ type PersistentChild struct {
 	stdout  *os.File
 	stderr  *os.File
 
-	mu        sync.Mutex // serializes request/response on stdin/stdout
+	buf        *RingBuffer
+	readerErr  atomic.Pointer[error] // set by readLoop on fatal pipe error
+	firstFrame chan struct{}         // closed after the first Store
+	done       chan struct{}         // closed when readLoop exits
+
 	closeOnce sync.Once
 }
 
@@ -141,10 +150,11 @@ func makeInheritablePipe(childIsRead bool) (child, parent windows.Handle, err er
 
 // StartPersistentChild launches the current binary as a subprocess in the
 // active console session with stdio plumbed back over inheritable pipes.
-// cmdArgs is appended to the exec path. The returned PersistentChild can serve
-// many CaptureJPEG calls; on any I/O error the caller should Close it and
-// start a new one.
-func StartPersistentChild(cmdArgs string) (_ *PersistentChild, retErr error) {
+// cmdArgs is appended to the exec path. The child immediately begins capturing
+// the given display and streaming frames. The returned PersistentChild serves
+// LatestFrame from a lock-free ring buffer; on any fatal error the caller
+// should Close it and start a new one.
+func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (_ *PersistentChild, retErr error) {
 	execPath, err := os.Executable()
 	if err != nil {
 		return nil, err
@@ -234,32 +244,86 @@ func StartPersistentChild(cmdArgs string) (_ *PersistentChild, retErr error) {
 	windows.CloseHandle(stdoutChild)
 	windows.CloseHandle(stderrChild)
 
-	return &PersistentChild{
-		process: pi.Process,
-		thread:  pi.Thread,
-		stdin:   os.NewFile(uintptr(stdinParent), "child-stdin"),
-		stdout:  os.NewFile(uintptr(stdoutParent), "child-stdout"),
-		stderr:  os.NewFile(uintptr(stderrParent), "child-stderr"),
-	}, nil
+	stdinFile := os.NewFile(uintptr(stdinParent), "child-stdin")
+
+	// Send initial config (display index) to the child.
+	if err := writeConfig(stdinFile, displayIndex); err != nil {
+		stdinFile.Close()
+		windows.CloseHandle(pi.Process)
+		windows.CloseHandle(pi.Thread)
+		return nil, fmt.Errorf("writing initial config: %w", err)
+	}
+
+	pc := &PersistentChild{
+		process:    pi.Process,
+		thread:     pi.Thread,
+		stdin:      stdinFile,
+		stdout:     os.NewFile(uintptr(stdoutParent), "child-stdout"),
+		stderr:     os.NewFile(uintptr(stderrParent), "child-stderr"),
+		buf:        NewRingBuffer(bufferSize),
+		firstFrame: make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+	go pc.readLoop()
+
+	// Wait for the first frame so callers don't get "no frame yet" immediately.
+	select {
+	case <-pc.firstFrame:
+	case <-pc.done:
+		// readLoop exited before delivering a frame.
+		if ep := pc.readerErr.Load(); ep != nil {
+			return nil, fmt.Errorf("child exited before first frame: %w", *ep)
+		}
+		return nil, errors.New("child exited before first frame")
+	case <-time.After(10 * time.Second):
+		pc.Close()
+		return nil, errors.New("timed out waiting for first frame from child")
+	}
+
+	return pc, nil
 }
 
-// CaptureJPEG asks the child to capture the given display and returns the
-// JPEG payload it writes back. Safe for concurrent callers (calls are
-// serialized internally so they don't interleave on the pipes).
-func (p *PersistentChild) CaptureJPEG(displayIndex uint32) ([]byte, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if err := writeRequest(p.stdin, displayIndex); err != nil {
-		return nil, fmt.Errorf("writing capture request: %w", err)
+// readLoop reads frames from the child's stdout pipe and stores them in the
+// ring buffer. It runs until the pipe is closed or an error occurs.
+func (p *PersistentChild) readLoop() {
+	defer close(p.done)
+	first := true
+	for {
+		start := time.Now()
+		data, err := readFrame(p.stdout)
+		if err != nil {
+			p.readerErr.Store(&err)
+			return
+		}
+		p.buf.Store(data)
+		done := time.Now()
+		if done.Sub(start) > 800*time.Millisecond {
+			fmt.Fprintf(os.Stderr, "getting latest screenshot from child at %v took %v\n", done, done.Sub(start))
+		}
+		if first {
+			close(p.firstFrame)
+			first = false
+		}
 	}
-	status, payload, err := readResponse(p.stdout)
-	if err != nil {
-		return nil, fmt.Errorf("reading capture response: %w", err)
+}
+
+// LatestFrame returns the most recently captured screenshot as JPEG bytes.
+// It never blocks on pipe I/O; the data comes from the lock-free ring buffer.
+func (p *PersistentChild) LatestFrame() ([]byte, error) {
+	if ep := p.readerErr.Load(); ep != nil {
+		return nil, *ep
 	}
-	if status != statusOK {
-		return nil, fmt.Errorf("child capture error: %s", string(payload))
+	data := p.buf.Load()
+	if data == nil {
+		return nil, errors.New("no frame available yet")
 	}
-	return payload, nil
+	return data, nil
+}
+
+// UpdateDisplayIndex sends a new display index to the child. The child's
+// capture loop picks it up atomically on the next iteration.
+func (p *PersistentChild) UpdateDisplayIndex(displayIndex uint32) error {
+	return writeConfig(p.stdin, displayIndex)
 }
 
 // Stderr returns a reader for the child's stderr stream. The caller MUST
@@ -273,8 +337,13 @@ func (p *PersistentChild) Stderr() io.Reader {
 // multiple times.
 func (p *PersistentChild) Close() error {
 	p.closeOnce.Do(func() {
-		// Closing stdin signals EOF to the child loop, which exits cleanly.
+		// Closing stdin signals EOF to the child's config-reading goroutine,
+		// which causes the capture loop to exit.
 		_ = p.stdin.Close()
+		select {
+		case <-p.done:
+		case <-time.After(2 * time.Second):
+		}
 		event, _ := windows.WaitForSingleObject(p.process, 2000)
 		if event != 0 { // not WAIT_OBJECT_0 -> didn't exit in time, force it
 			_ = windows.TerminateProcess(p.process, 1)

--- a/subproc/spawn_windows.go
+++ b/subproc/spawn_windows.go
@@ -136,13 +136,15 @@ func (p *PersistentChild) Closed() bool { return p.closed.Load() }
 
 // makeInheritablePipe creates an anonymous pipe with both ends inheritable,
 // then clears the inherit flag on the parent's end so only the child end is
-// duplicated into the child by CreateProcessAsUser.
-func makeInheritablePipe(childIsRead bool) (child, parent windows.Handle, err error) {
+// duplicated into the child by CreateProcessAsUser. bufferSizeHint is a hint to
+// the kernel for the pipe buffer size; pass 0 to use the system default
+// (~4 KB on Windows).
+func makeInheritablePipe(childIsRead bool, bufferSizeHint uint32) (child, parent windows.Handle, err error) {
 	var sa windows.SecurityAttributes
 	sa.Length = uint32(unsafe.Sizeof(sa))
 	sa.InheritHandle = 1
 	var r, w windows.Handle
-	if err := windows.CreatePipe(&r, &w, &sa, 0); err != nil {
+	if err := windows.CreatePipe(&r, &w, &sa, bufferSizeHint); err != nil {
 		return 0, 0, err
 	}
 	if childIsRead {
@@ -175,7 +177,7 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 	}
 	defer token.Close()
 
-	stdinChild, stdinParent, err := makeInheritablePipe(true)
+	stdinChild, stdinParent, err := makeInheritablePipe(true, 0)
 	if err != nil {
 		return nil, fmt.Errorf("creating stdin pipe: %w", err)
 	}
@@ -185,7 +187,7 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 		}
 	}()
 
-	stdoutChild, stdoutParent, err := makeInheritablePipe(false)
+	stdoutChild, stdoutParent, err := makeInheritablePipe(false, 1<<20)
 	if err != nil {
 		windows.CloseHandle(stdinChild)
 		return nil, fmt.Errorf("creating stdout pipe: %w", err)
@@ -196,7 +198,7 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 		}
 	}()
 
-	stderrChild, stderrParent, err := makeInheritablePipe(false)
+	stderrChild, stderrParent, err := makeInheritablePipe(false, 0)
 	if err != nil {
 		windows.CloseHandle(stdinChild)
 		windows.CloseHandle(stdoutChild)

--- a/subproc/spawn_windows.go
+++ b/subproc/spawn_windows.go
@@ -166,17 +166,32 @@ func makeInheritablePipe(childIsRead bool, bufferSizeHint uint32) (child, parent
 // the given display and streaming frames. The returned PersistentChild serves
 // LatestFrame from a lock-free ring buffer; on any fatal error the caller
 // should Close it and start a new one.
+// The child will close when the parent terminates, since it exits on EOF from stdin or write error to stdout
+// and the OS will close these when the parent process exits, whether cleanly or uncleanly.
 func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (_ *PersistentChild, retErr error) {
+	// Path to this same exe — we spawn a copy of ourselves with different args.
 	execPath, err := os.Executable()
 	if err != nil {
 		return nil, err
 	}
+	// Get a primary token for the active console user. Required because we run
+	// as LocalSystem in session 0 but the child needs to be in the user's
+	// session so it can see the desktop. Calls WTSGetActiveConsoleSessionId +
+	// WTSQueryUserToken under the hood (needs SE_TCB_PRIVILEGE).
 	token, err := activeUserToken()
 	if err != nil {
 		return nil, err
 	}
 	defer token.Close()
 
+	// Three anonymous pipes for child stdio. makeInheritablePipe creates each
+	// pipe with both ends inheritable, then clears the inherit flag on the
+	// parent's end so only the child end gets duplicated by CreateProcessAsUser.
+	//
+	// childIsRead=true for stdin (child reads from us), false for stdout/stderr
+	// (child writes to us). Each defer closes the parent end ONLY if the
+	// function returns an error — on success the parent end lives on in the
+	// returned PersistentChild.
 	stdinChild, stdinParent, err := makeInheritablePipe(true, 0)
 	if err != nil {
 		return nil, fmt.Errorf("creating stdin pipe: %w", err)
@@ -189,6 +204,8 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 
 	stdoutChild, stdoutParent, err := makeInheritablePipe(false, 1<<20)
 	if err != nil {
+		// Manual cleanup of previously-allocated child-side handle since there's
+		// no defer for it (we close it explicitly after CreateProcessAsUser).
 		windows.CloseHandle(stdinChild)
 		return nil, fmt.Errorf("creating stdout pipe: %w", err)
 	}
@@ -210,8 +227,14 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 		}
 	}()
 
+	// Build StartupInfo. Cb must be filled in with the struct size for forward
+	// compat (Win32 versioning convention).
 	si := new(windows.StartupInfo)
 	si.Cb = uint32(unsafe.Sizeof(*si))
+	// Pin the child to the interactive user desktop. Without this it would land
+	// on the service desktop (Service-0x0-3e7$\Default) and BitBlt would
+	// capture nothing useful. The "Winsta0\Default" string is a fixed
+	// Windows-internal name, never localized.
 	si.Desktop, err = syscall.UTF16PtrFromString("Winsta0\\Default")
 	if err != nil {
 		windows.CloseHandle(stdinChild)
@@ -219,11 +242,16 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 		windows.CloseHandle(stderrChild)
 		return nil, err
 	}
+	// STARTF_USESTDHANDLES makes StdInput/StdOutput/StdErr below take effect.
+	// Without this flag they're ignored.
 	si.Flags = windows.STARTF_USESTDHANDLES
 	si.StdInput = stdinChild
 	si.StdOutput = stdoutChild
 	si.StdErr = stderrChild
 
+	// Build the command line as a wide string (Win32 expects LPWSTR).
+	// Format: "<exepath> <args>". Windows parses this back into argv on the
+	// child side.
 	cmdLine, err := syscall.UTF16PtrFromString(execPath + " " + cmdArgs)
 	if err != nil {
 		windows.CloseHandle(stdinChild)
@@ -232,17 +260,19 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 		return nil, err
 	}
 
+	// Spawn the child as the active console user. pi receives the child's
+	// process+thread handles and PID/TID. bInheritHandles=true is what makes
+	// our inheritable pipe ends actually duplicate into the child.
 	pi := new(windows.ProcessInformation)
 	if err := windows.CreateProcessAsUser(
-		token,
-		nil,
+		token, // user token from activeUserToken()
+		nil,   // app name (nil = parse from cmdLine)
 		cmdLine,
-		nil,
-		nil,
+		nil, nil, // process/thread security attributes (nil = default)
 		true, // bInheritHandles: required so the child receives our pipe ends
-		0,
-		nil,
-		nil,
+		0,    // creation flags (none — child gets default subsystem behavior)
+		nil,  // environment (nil = inherit user's environment)
+		nil,  // current directory (nil = inherit)
 		si,
 		pi,
 	); err != nil {
@@ -251,14 +281,22 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 		windows.CloseHandle(stderrChild)
 		return nil, fmt.Errorf("CreateProcessAsUser failed: %v", err)
 	}
-	// The child now owns duplicates of the child-side handles; close ours.
+	// Close OUR copies of the child-side handles. The child now has duplicates
+	// of these as its stdio handles. If we kept them open, the OS would think
+	// the pipes are still alive even when the child exits — so we'd never see
+	// EOF on read and shutdown detection would break.
 	windows.CloseHandle(stdinChild)
 	windows.CloseHandle(stdoutChild)
 	windows.CloseHandle(stderrChild)
 
+	// Wrap our parent-side stdin handle as a Go *os.File so we can use
+	// Write/Close instead of raw Win32 calls.
 	stdinFile := os.NewFile(uintptr(stdinParent), "child-stdin")
 
-	// Send initial config (display index) to the child.
+	// Send the first config message — 4 bytes of LE uint32 display index.
+	// The child's RunContinuousChildLoop blocks at startup waiting for this
+	// (see readConfig at the top of that function). The deferred handle
+	// cleanups don't cover pi.Process/pi.Thread, so close them manually here.
 	if err := writeConfig(stdinFile, displayIndex); err != nil {
 		stdinFile.Close()
 		windows.CloseHandle(pi.Process)
@@ -266,6 +304,9 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 		return nil, fmt.Errorf("writing initial config: %w", err)
 	}
 
+	// Hand off ownership of all parent-side resources to the PersistentChild.
+	// firstFrame/done are signaled by readLoop: firstFrame closes after the
+	// first successful Store, done closes when readLoop exits.
 	pc := &PersistentChild{
 		process:    pi.Process,
 		thread:     pi.Thread,
@@ -276,9 +317,15 @@ func StartPersistentChild(cmdArgs string, displayIndex uint32, bufferSize int) (
 		firstFrame: make(chan struct{}),
 		done:       make(chan struct{}),
 	}
+	// Start the background frame reader. It loops on readFrame(p.stdout) and
+	// stores each payload into the ring buffer.
 	go pc.readLoop()
 
-	// Wait for the first frame so callers don't get "no frame yet" immediately.
+	// Wait for the first frame so callers don't get "no frame yet" from their
+	// initial LatestFrame() call. Three outcomes:
+	//   - firstFrame fires: child is streaming; happy path.
+	//   - done fires first: child crashed before producing any output.
+	//   - timeout: child is alive but stuck; tear it down and return an error.
 	select {
 	case <-pc.firstFrame:
 	case <-pc.done:

--- a/subproc/spawn_windows.go
+++ b/subproc/spawn_windows.go
@@ -120,9 +120,19 @@ type PersistentChild struct {
 	readerErr  atomic.Pointer[error] // set by readLoop on fatal pipe error
 	firstFrame chan struct{}         // closed after the first Store
 	done       chan struct{}         // closed when readLoop exits
+	closed     atomic.Bool           // set by Close() before teardown
 
 	closeOnce sync.Once
 }
+
+// Done returns a channel that is closed when the child process has exited
+// (either crashed or was closed by the parent). Callers can select on it to
+// detect child death.
+func (p *PersistentChild) Done() <-chan struct{} { return p.done }
+
+// Closed reports whether Close() has been called. Used to distinguish clean
+// shutdown from unexpected child death.
+func (p *PersistentChild) Closed() bool { return p.closed.Load() }
 
 // makeInheritablePipe creates an anonymous pipe with both ends inheritable,
 // then clears the inherit flag on the parent's end so only the child end is
@@ -337,6 +347,9 @@ func (p *PersistentChild) Stderr() io.Reader {
 // multiple times.
 func (p *PersistentChild) Close() error {
 	p.closeOnce.Do(func() {
+		// Mark closed BEFORE teardown so supervisors watching Done() can tell
+		// this was a clean shutdown rather than a crash.
+		p.closed.Store(true)
 		// Closing stdin signals EOF to the child's config-reading goroutine,
 		// which causes the capture loop to exit.
 		_ = p.stdin.Close()


### PR DESCRIPTION
For Windows only:
* Restore the original one-off child mode (each incoming `GetImage(s)` call spawns a short-lived child process to take a screenshot on demand) removed in 1149d672f13fee91fc1b8ab25e2a81e71b43caff, since persistent mode is not needed in most use cases.
* Improve and optimize persistent mode added in 1149d672f13fee91fc1b8ab25e2a81e71b43caff (which was also done by Claude), most importantly by re-enabling parallelism. The current one [serializes all incoming GetImage(s) requests](https://github.com/viam-labs/screenshot-cam/blob/d4c3da77fc571e6645f68fbb46ca27ac03ed1a8b/subproc/spawn_windows.go#L247-L255), which can result in `GetImage(s)` taking up to 3s to return when called with >3 callers per second.
* add option to resize image after taking it, which can help save IPC bandwith.

In my testing, I can see the persistent mode child process screenshotting every ~80-110ms (~10 fps), and `GetImage(s)` calls returning the latest available image in <40ms, and often under 10ms. The returned image freshness should not be any worse (usually much better) compared with the previous one-off child mode.

Note: if the persistent child crashes (most likely due to external factors like system OOM), the parent process will exit, and RDK will restart it.